### PR TITLE
fix: broken linkedin link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ footer-links:
   flickr:
   github: ossd-s24
   instagram: 
-  linkedin: https://www.linkedin.com/in/ben-yu-zhang/
+  linkedin: ben-yu-zhang
   pinterest:
   twitter:
   stackoverflow: # your stackoverflow profile, e.g. "users/50476/bart-kiers"


### PR DESCRIPTION
The LinkedIn field should only include the username for the link to work correctly!